### PR TITLE
Update the add `feelpp` package PR for `spack`: add boost defaults, readline, python@:3.11

### DIFF
--- a/var/spack/repos/builtin/packages/feelpp/package.py
+++ b/var/spack/repos/builtin/packages/feelpp/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Feelpp(CMakePackage):
@@ -49,7 +50,8 @@ class Feelpp(CMakePackage):
     depends_on("cmake@3.21:", type="build")
     depends_on("llvm@14.0.0:")
     depends_on("mpi")
-    depends_on("boost@1.74: +filesystem+iostreams+mpi+multithreaded+shared")
+    depends_on(Boost.with_default_variants)
+    depends_on("boost@1.74: +mpi+multithreaded+shared")
     depends_on("petsc@3.20 +mumps+hwloc+ptscotch +suite-sparse+hdf5 +hypre+kokkos")
     depends_on("slepc")
     depends_on("cln@1.3.6")
@@ -65,6 +67,7 @@ class Feelpp(CMakePackage):
     depends_on("ruby")
     depends_on("gmsh +opencascade+mmg+fltk")
     depends_on("curl")
+    depends_on("readline")
 
     # Python dependencies if +python variant is enabled
     depends_on("py-pytest", when="+python")
@@ -80,7 +83,7 @@ class Feelpp(CMakePackage):
     depends_on("py-ipykernel", when="+python")
     depends_on("py-mpi4py", when="+python")
     depends_on("py-tqdm", when="+python")
-    depends_on("python@3.7:", when="+python", type=("build", "run"))
+    depends_on("python@3.7:3.11", when="+python", type=("build", "run"))
 
     def get_preset_name(self):
         spec = self.spec


### PR DESCRIPTION
@prudhomm @vincentchabannes, this "PR for the PR" contains the fixes that I've found so far:

- https://github.com/spack/spack/pull/46396#pullrequestreview-2363892769: Use Boost.with_default_variants
- - https://github.com/spack/spack/pull/46396#pullrequestreview-2363892769: feelpp uses `distutils`: Incompatible with `Python@3.12:`
  - TODO: Replace the use of `distutils` (which was removed in 3.12) with `setuptools` to support newer Python versions (and avoid build warnings about it too) in upstream feelpp itself.
  - https://github.com/spack/spack/pull/46396#pullrequestreview-2363902130: Add a missing dependency on readline. Maybe also needs a cmake include directories fix like for PugiXML when libreadline-devel is uninstalled from the build host.

PS, further FIXMEs before the build can be done on a freshly installed host in spack:
- You also need to fix add  ${PUGIXML_INCLUDE_DIR} to target_include_directories in one of the two ways mentioned here when PugiXML is not installed on the host system: https://github.com/feelpp/FMI4cpp/pull/3
- Same fore fftw3: https://github.com/spack/spack/pull/46396
- Maybe the same for readline (in addition to the depend_on for readline)

PPS: Your last [Merge branch 'develop' into 4-add-package-for-feelpp](https://github.com/spack/spack/pull/46396/commits/0ce17c1219d08e4dbf29593ad48cec5269f50ba5) merged a two bad commit from the develop branch into your PR branch https://github.com/feelpp/spack/tree/4-add-package-for-feelpp:

These two bad commits have been reverted in develop afterwards, but your PR branch has not been updated or rebased to a newer develop that reverts those bad commits yet.

The result is that when trying to build `feelpp`, the spack compiler wrapper script (which are bad in this commit) are very very very very slow: A single compiler call has about one second of additional CPU time which makes all compiler probing take ages. This caused many builds in CI to take longer than 6 hours and was a cause of major failures and backlogs. Therefore, you need to urgently rebase it to a new develop branch before resuming test builds for testing your PR:
```py
git remote add upstream https://github.com/feelpp/feelpp.git
git rebase upstream/develop
```
When updating your branch, DO NOT USE "Update with merge commit" but "Update with rebase".

Using rebase keeps (or brings your commits) on top of the commit tree, which is what you want to review your commits.

You may also possibly consider squashing your commits for the new recipe into one to consolidate the commits (only now, not always) as many commits accumulated in the PR branch.
